### PR TITLE
Add BLE alert feature for high PM2.5 levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ A [PlatformIO](https://platformio.org/project) project for the Seeed Wio Termina
   - Accessible via BLE
 - Time synchronization:
   - Set the device time via BLE
+- Alerting:
+  - BLE alerts for high PM2.5 levels
 
 ## BLE Service Specifications
 
@@ -45,6 +47,7 @@ A [PlatformIO](https://platformio.org/project) project for the Seeed Wio Termina
   - PM10: `91bad495-b950-4226-aa2b-4ede9fa42f59` (Read, Notify)
   - History: `91bad496-b950-4226-aa2b-4ede9fa42f59` (Read)
   - Time Sync: `91bad497-b950-4226-aa2b-4ede9fa42f59` (Write)
+  - Alert: `91bad498-b950-4226-aa2b-4ede9fa42f59` (Read, Notify)
 
 ## BLE Client/Central Example App
 - [Flutter PM2.5 Monitor App](https://github.com/IoT-gamer/flutter_pm2_5_monitor_app)


### PR DESCRIPTION
This pull request introduces a new alerting feature for high PM2.5 levels in the Seeed Wio Terminal project. The changes include updates to the documentation and modifications to the main application code to support BLE alerts.

### Documentation Updates:
* Added a new section for BLE alerts for high PM2.5 levels in the `README.md` file.
* Included the new `Alert` characteristic in the BLE Service Specifications section of the `README.md` file.

### Code Updates:
* Defined a new UUID for the `Alert` characteristic and a PM2.5 threshold constant in `src/main.cpp`.
* Added a new `BLECharacteristic` pointer for the alert characteristic in `src/main.cpp`.
* Implemented logic to check PM2.5 levels and send alerts if the threshold is exceeded in the `updateReadings` function in `src/main.cpp`.
* Created and configured the new alert characteristic in the `setup` function in `src/main.cpp`.